### PR TITLE
issues/2 - ToGuid moved to string extension and can accept nullable string

### DIFF
--- a/src/Bolt.Common.Extensions/GuidExtensions.cs
+++ b/src/Bolt.Common.Extensions/GuidExtensions.cs
@@ -1,22 +1,20 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 namespace Bolt.Common.Extensions
 {
     public static class GuidExtensions
     {
         [DebuggerStepThrough]
-        public static Guid? ToGuid(this string source)
-        {
-            Guid result;
-            return Guid.TryParse(source, out result) ? result : (Guid?)null;
-        }
-
-        [DebuggerStepThrough]
         public static bool IsEmpty(this Guid? source)
         {
             return source == null || source.Value == Guid.Empty;
         }
+
+        [DebuggerStepThrough]
+        public static bool IsEmpty(this Guid source)
+        {
+            return source == Guid.Empty;
+        }        
 
         [DebuggerStepThrough]
         public static bool HasValue(this Guid? source)
@@ -25,15 +23,9 @@ namespace Bolt.Common.Extensions
         }
 
         [DebuggerStepThrough]
-        public static bool IsEmpty(this Guid source)
-        {
-            return source == Guid.Empty;
-        }
-
-        [DebuggerStepThrough]
         public static bool HasValue(this Guid source)
         {
             return source != Guid.Empty;
-        }
+        }        
     }
 }

--- a/src/Bolt.Common.Extensions/StringExtensions.cs
+++ b/src/Bolt.Common.Extensions/StringExtensions.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Linq;
 using System.Reflection;
 
 namespace Bolt.Common.Extensions
@@ -222,5 +218,11 @@ namespace Bolt.Common.Extensions
             if (source == null) return string.Empty;
             return string.Format(source, args);
         }
+
+        [DebuggerStepThrough]
+        public static Guid? ToGuid(this string? source)
+        {
+            return Guid.TryParse(source, out var result) ? result : null;
+        }        
     }
 }


### PR DESCRIPTION
1. Guid Extension ToGuid moved to string extension.
2. ToGuid can accept nullable string. 
3. Guid Extension methods made adjacent. 